### PR TITLE
Fix library issue when compiling on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ if(MSVC)
     add_compile_options(/bigobj)
 endif()
 
+set(Boost_USE_STATIC_LIBS ON)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)


### PR DESCRIPTION
When compiling on Windows i het the following error:
`LINK : fatal error LNK1104: cannot open file 'libboost_regex-vc142-mt-x64-1_74.lib' [C:\dev\sim_ros2_interface\build\sim_ros2_interface\simExtROS2.vcxproj]`

After some debugging I found the fix from this pull request. Namely adding:
`set(Boost_USE_STATIC_LIBS ON)` 
to Cmakelist.txt

## Extra information
```
For some more information about my environment and for reproducing the bug:
colcon build --event-handlers console_direct+
Starting >>> sim_ros2_interface
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19042.
-- Found ament_cmake: 0.9.8 (C:/dev/ros2_foxy/install/share/ament_cmake/cmake)
-- Using PYTHON_EXECUTABLE: C:/Python38/python.exe
-- Found ament_cmake_ros: 0.9.1 (C:/dev/ros2_foxy/install/share/ament_cmake_ros/cmake)
-- Found diagnostic_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/diagnostic_msgs/cmake)
-- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
-- Found rosidl_adapter: 1.2.1 (C:/dev/ros2_foxy/install/share/rosidl_adapter/cmake)
-- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
-- Found geometry_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/geometry_msgs/cmake)
-- Found lifecycle_msgs: 1.0.0 (C:/dev/ros2_foxy/install/share/lifecycle_msgs/cmake)
-- Found map_msgs: 2.0.2 (C:/dev/ros2_foxy/install/share/map_msgs/cmake)
-- Found pendulum_msgs: 0.9.3 (C:/dev/ros2_foxy/install/share/pendulum_msgs/cmake)
-- Found rosgraph_msgs: 1.0.0 (C:/dev/ros2_foxy/install/share/rosgraph_msgs/cmake)
-- Found shape_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/shape_msgs/cmake)
-- Found stereo_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/stereo_msgs/cmake)
-- Found tf2_geometry_msgs: 0.13.10 (C:/dev/ros2_foxy/install/share/tf2_geometry_msgs/cmake)
-- Found eigen3_cmake_module: 0.1.1 (C:/dev/ros2_foxy/install/share/eigen3_cmake_module/cmake)
-- Found rmw_implementation_cmake: 1.0.3 (C:/dev/ros2_foxy/install/share/rmw_implementation_cmake/cmake)
-- Using RMW implementation 'rmw_fastrtps_cpp' as default
-- Found trajectory_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/trajectory_msgs/cmake)
-- Found visualization_msgs: 2.0.4 (C:/dev/ros2_foxy/install/share/visualization_msgs/cmake)
-- Found std_srvs: 2.0.4 (C:/dev/ros2_foxy/install/share/std_srvs/cmake)
-- Found example_interfaces: 0.9.1 (C:/dev/ros2_foxy/install/share/example_interfaces/cmake)
-- Found image_transport: 2.3.0 (C:/dev/image_common/install/image_transport/share/image_transport/cmake)
-- TinyXML2 was already found when tinyxml2_vendor was included, adding missing imported target tinyxml2::tinyxml2
-- Found twi_interfaces: 0.0.0 (C:/dev/1257-wintrack-inspection-robot/Robot/install/twi_interfaces/share/twi_interfaces/cmake)
-- CoppeliaSim: LIBPLUGIN_DIR: C:/Program Files/CoppeliaRobotics/CoppeliaSimPro/programming/libPlugin.
-- CoppeliaSim: COPPELIASIM_ROOT_DIR: C:/Program Files/CoppeliaRobotics/CoppeliaSimPro.
-- Found CoppeliaSim installation at C:/Program Files/CoppeliaRobotics/CoppeliaSimPro.
-- Checking CoppeliaSim header version...
-- CoppeliaSim headers version 4.2.0 rev4
-- Found Boost: C:/local/boost_1_74_0 (found version "1.74.0") found components: regex
-- Found Boost: C:/local/boost_1_74_0 (found version "1.74.0")
-- Adding simStubsGen command...
-- Reading plugin metadata...
-- Plugin: ROS2
-- Configuring done
-- Generating done
-- Build files have been written to: C:/dev/sim_ros2_interface/build/sim_ros2_interface
Microsoft (R) Build Engine version 16.9.0+5e4b48a27 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/dev/sim_ros2_interface/CMakeLists.txt
  Building Custom Rule C:/dev/sim_ros2_interface/CMakeLists.txt
LINK : fatal error LNK1104: cannot open file 'libboost_regex-vc142-mt-x64-1_74.lib' [C:\dev\sim_ros2_interface\build\sim_ros2_interface\simExtROS2.vcxproj]
Failed   <<< sim_ros2_interface [8.41s, exited with code 1]
```