### PR TITLE
ROS2 Galactic rclcpp::executor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Supported ROS2 versions:
 
  - Foxy Fitzroy
+ - Galactic Geochelone
 
 ### Compiling
 

--- a/templates/actcli_sendGoal.cpp
+++ b/templates/actcli_sendGoal.cpp
@@ -44,7 +44,7 @@
             ros_action_callback__`interface.result.cpp_type_normalized`(actionClientProxy->resultCallback.scriptId, actionClientProxy->resultCallback.name.c_str(), result.goal_id, lua_code, result.result, actionClientProxy);
         };
         auto goal_handle_future = cli->async_send_goal(goal_msg, send_goal_options);
-        out->success = rclcpp::spin_until_future_complete(node, goal_handle_future) == rclcpp::executor::FutureReturnCode::SUCCESS;
+        out->success = rclcpp::spin_until_future_complete(node, goal_handle_future) == rclcpp::FutureReturnCode::SUCCESS;
         rclcpp_action::ClientGoalHandle<`interface.cpp_type`>::SharedPtr goal_handle = goal_handle_future.get();
         actionClientProxy->last_goal_handle = goal_handle;
     }

--- a/templates/cli_call.cpp
+++ b/templates/cli_call.cpp
@@ -9,7 +9,7 @@
         read__`interface.request.cpp_type_normalized`(in->_.stackID, req.get(), &(clientProxy->rd_opt));
         auto result = cli->async_send_request(req);
         if(rclcpp::spin_until_future_complete(node, result) ==
-                rclcpp::executor::FutureReturnCode::SUCCESS)
+                rclcpp::FutureReturnCode::SUCCESS)
         {
             auto resp = result.get();
             write__`interface.response.cpp_type_normalized`(*resp, in->_.stackID, &(clientProxy->wr_opt));


### PR DESCRIPTION
I made changes so that **simExtROS2** compiles without errors in a **ROS2 Galactic** workspace.